### PR TITLE
Remove SQL column, not found in CSV

### DIFF
--- a/scripts/aggregate_trips.sql
+++ b/scripts/aggregate_trips.sql
@@ -12,7 +12,6 @@ create table trips (
   "end station latitude" numeric,
   "end station longitude" numeric,
   "bikeid" varchar,
-  "name_localizedValue0" varchar,
   "usertype" varchar,
   "birth year" varchar,
   "gender" varchar


### PR DESCRIPTION
Fixes the error, when trying to import data from CSV.

```
db=# copy trips from '201805-citibike-tripdata.csv' delimiter ',' csv header;
ERROR:  missing data for column "gender"
```
